### PR TITLE
Add standard gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Node/Vite common ignores
+node_modules/
+dist/
+.env
+.env.*
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+# Editor directories and files
+.DS_Store
+.vscode/
+.idea/
+# Build output
+.vite/
+


### PR DESCRIPTION
## Summary
- add `.gitignore` ignoring common Node/Vite outputs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68441a24b27c833391c1c521aecb0d3f